### PR TITLE
Remove redundant (/harmful) quote_ident

### DIFF
--- a/audit.sql
+++ b/audit.sql
@@ -186,15 +186,15 @@ DECLARE
   _q_txt text;
   _ignored_cols_snip text = '';
 BEGIN
-    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || quote_ident(target_table::TEXT);
-    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || quote_ident(target_table::TEXT);
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_table::TEXT;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_table::TEXT;
 
     IF audit_rows THEN
         IF array_length(ignored_cols,1) > 0 THEN
             _ignored_cols_snip = ', ' || quote_literal(ignored_cols);
         END IF;
         _q_txt = 'CREATE TRIGGER audit_trigger_row AFTER INSERT OR UPDATE OR DELETE ON ' || 
-                 quote_ident(target_table::TEXT) || 
+                 target_table::TEXT ||
                  ' FOR EACH ROW EXECUTE PROCEDURE audit.if_modified_func(' ||
                  quote_literal(audit_query_text) || _ignored_cols_snip || ');';
         RAISE NOTICE '%',_q_txt;


### PR DESCRIPTION
This fix allows setting audit trigger on schema-qualified tables not on the search path, e.g.

`select audit.audit_table('some_schema.some_table'::regclass)`
`select audit.audit_table('some_schema."some table"'::regclass)`

Without it, the whole object name is `quote_ident`-ed, resulting in errors like:

`ERROR: relation "some_schema.some_table" does not exist`

The cast from `regclass` -> `text` takes care of quoting...

```
venue=> CREATE SCHEMA test_schema;
CREATE SCHEMA
venue=> CREATE TABLE test_schema."test table"();
CREATE TABLE
venue=> SELECT 'test_schema."test table"'::regclass::text;
-[ RECORD 1 ]------------------
text | test_schema."test table"

(1 row)
```

 so the quote_ident can simply be removed.
