### PR TITLE
Adds ability to replay edits and log views 

### DIFF
--- a/audit.sql
+++ b/audit.sql
@@ -292,7 +292,7 @@ $body$;
 
 CREATE OR REPLACE FUNCTION audit.audit_view(target_view regclass, audit_query_text BOOLEAN, ignored_cols text[]) RETURNS void AS $body$
 DECLARE
-  stm_targets text = 'INSERT OR UPDATE OR DELETE OR TRUNCATE';
+  stm_targets text = 'INSERT OR UPDATE OR DELETE';
   _q_txt text;
 BEGIN
     EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_view::text;

--- a/audit.sql
+++ b/audit.sql
@@ -339,9 +339,12 @@ BEGIN
 	RAISE NOTICE '%',_q_txt;
 	EXECUTE _q_txt;
 
-    -- store uid columns
-    insert into audit.logged_relations (relation_name, uid_column)
-         select target_view, unnest(uid_cols);
+    -- store uid columns if not already present
+  IF (select count(*) from audit.logged_relations where relation_name = (select target_view)::text AND  uid_column= (select unnest(uid_cols))::text) = 0 THEN
+      insert into audit.logged_relations (relation_name, uid_column)
+       select target_view, unnest(uid_cols);
+  END IF;    
+
 END;
 $body$
 LANGUAGE plpgsql;

--- a/audit.sql
+++ b/audit.sql
@@ -142,8 +142,8 @@ BEGIN
     IF (TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW') THEN
         h_old = hstore(OLD.*) - excluded_cols;
         audit_row.row_data = h_old;
-	h_new = hstore(NEW.*)- excluded_cols;
-	audit_row.changed_fields =  h_new - h_old;
+  h_new = hstore(NEW.*)- excluded_cols;
+  audit_row.changed_fields =  h_new - h_old;
 
         IF audit_row.changed_fields = hstore('') THEN
             -- All changed fields are ignored. Skip this update.
@@ -152,16 +152,18 @@ BEGIN
         END IF;
     ELSIF (TG_OP = 'DELETE' AND TG_LEVEL = 'ROW') THEN
         audit_row.row_data = hstore(OLD.*) - excluded_cols;
+        RETURN OLD;
     ELSIF (TG_OP = 'INSERT' AND TG_LEVEL = 'ROW') THEN
         audit_row.row_data = hstore(NEW.*) - excluded_cols;
+        RETURN NEW;
     ELSIF (TG_LEVEL = 'STATEMENT' AND TG_OP IN ('INSERT','UPDATE','DELETE','TRUNCATE')) THEN
         audit_row.statement_only = 't';
+  RETURN NULL;
     ELSE
         RAISE EXCEPTION '[audit.if_modified_func] - Trigger func added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
         RETURN NEW;
     END IF;
     INSERT INTO audit.logged_actions VALUES (audit_row.*);
-    RETURN NEW;
 END;
 $body$
 LANGUAGE plpgsql


### PR DESCRIPTION
And also merges PR #20 #22 #21 
Authors: Sylvain Beorchia, Hugo Mercier, Régis Haubourg (all from [Oslandia](http://oslandia.com/))
This PR adds:
- a new function to create a instead of row level trigger for auditing views.
- a new table logged_relation is added to keep track of identifier columns used to replay updates or deletes for views (primary keys are not accessible through catalog views)
- a new function replay_event(event_id) is also added to ease replaying stored actions. 

This PR goes in sync with a QGIS plugin (A great Open Source GIS tool) that allows to search logged actions and replay old edits. It can be found here  https://github.com/qwat/pg-history-viewer 

We'd love to see that merged so that the postgresql community keeps one only reference for that awesome audit trigger. Please tell me if that sounds possible. 
